### PR TITLE
fix(deps): bump shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17778,9 +17778,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="
     },
     "node_modules/shellwords": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   "devDependencies": {
     "gh-pages": "^3.2.3",
     "prettier": "^2.4.1"
+  },
+  "overrides": {
+    "shell-quote@<1.8.4": "1.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "overrides": {
     "shell-quote@<1.8.4": "1.8.4"
+  },
+  "resolutions": {
+    "shell-quote": "1.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10705,9 +10705,9 @@
   "version" "3.0.0"
 
 "shell-quote@1.7.2":
-  "integrity" "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
-  "resolved" "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz"
-  "version" "1.7.2"
+  "integrity" "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="
+  "resolved" "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz"
+  "version" "1.8.4"
 
 "shellwords@^0.1.1":
   "integrity" "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="


### PR DESCRIPTION
## What
Pins **shell-quote** to **1.8.4** (was 1.7.2). Adds an npm `overrides` entry and surgically updates the resolved entry in **both** `package-lock.json` and `yarn.lock`.

```json
"overrides": {
  "shell-quote@<1.8.4": "1.8.4"
}
```

## Why
shell-quote `<1.8.4` carries a CRITICAL command-injection advisory, **CVE-2026-9277** (`quote()` mishandles line terminators in an object token's `.op` field, allowing command separation in POSIX shells). Fixed upstream in 1.8.4.

## Notes for the reviewer
- `react-dev-utils` requests shell-quote at an **exact** `1.7.2`, so the bump is applied through an `overrides` pin rather than a range change.
- Edits are **surgical** (only the shell-quote stanza in each lockfile) to avoid a full npm-11 lockfile regeneration, which would rewrite unrelated metadata across ~2000 packages.
- This repo installs with **npm** (per the README). The committed `yarn.lock` is stale leftover from the upstream fork (`tadhglewis/issue-status`); its shell-quote entry is bumped too so neither lockfile carries the advisory. Consider removing the unused `yarn.lock` in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)