### PR TITLE
fix(deps): bump websocket-driver 0.7.4 to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21553,9 +21553,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12194,9 +12194,9 @@
     "webpack-sources" "^1.4.1"
 
 "websocket-driver@^0.7.4", "websocket-driver@>=0.5.1":
-  "integrity" "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="
-  "resolved" "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz"
-  "version" "0.7.4"
+  "integrity" "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA=="
+  "resolved" "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz"
+  "version" "0.7.5"
   dependencies:
     "http-parser-js" ">=0.5.1"
     "safe-buffer" ">=5.1.0"


### PR DESCRIPTION
## What

Bumps the transitive dependency `websocket-driver` from 0.7.4 to 0.7.5 in **both** committed lockfiles (`package-lock.json` and `yarn.lock`, each a minimal 3-line change). No `package.json` edits; the requesting ranges (`>=0.5.1` from faye-websocket, `^0.7.4` from sockjs) already allow 0.7.5.

## Why

websocket-driver < 0.7.5 is affected by:
- **CVE-2026-54466** (critical): message corruption via abuse of protocol length headers
- **CVE-2026-54490** (medium): resource limit bypass via message compression

## Exposure

Dev-only in practice: the chain is `react-scripts -> webpack-dev-server -> sockjs -> faye-websocket`; the vulnerable code only runs in the local CRA dev server. The deployed site is a static gh-pages build. Patched to close the advisory cleanly.

## Verification

- Each lockfile diff touches only the websocket-driver entry; integrity hashes match the npm registry
- `npm ci` passes and installs websocket-driver 0.7.5
- `yarn install --frozen-lockfile` passes against the updated yarn.lock (validated in an isolated copy, since running npm in this repo auto-rewrites yarn.lock wholesale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)